### PR TITLE
Possibility to include timing information to each evaluated command

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Authors@R: c(
     person("Yihui", "Xie", role = c("cre", "ctb"), email = "xie@yihui.name"),
     person("Michael", "Lawrence", role = "ctb"),
     person("Thomas", "Kluyver", role = "ctb"),
-    person("Barret", "Schloerke", role = "ctb")
+    person("Barret", "Schloerke", role = "ctb"),
+    person("Adam", "Ryczkowski", role = "ctb")
     )
 Description: Parsing and evaluation tools that make it easy to recreate the
     command line behaviour of R.

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+Version 0.9.1
+------------------------------------------------------------------------------
+
+* Added option for the evaluate function to include timing information of ran
+  commands. This information will be subsequently rendered by the replay.
+  Example usage:
+  evaluate::replay(evaluate::evaluate('Sys.sleep(1)',include_timing = TRUE))
+
 Version 0.9
 ------------------------------------------------------------------------------
 

--- a/R/eval.r
+++ b/R/eval.r
@@ -169,12 +169,13 @@ evaluate_call <- function(call, src = NULL,
 
   multi_args <- length(formals(value_handler)) > 1
   for (expr in call) {
+    srcindex<-length(output)
     time<-timing_fn(handle(ev <- withCallingHandlers(
       withVisible(eval(expr, envir, enclos)),
       warning = wHandler, error = eHandler, message = mHandler)))
     handle_output(TRUE)
     if (!is.null(time))
-      attr(output[[length(output)]]$src,'timing')<-time
+      attr(output[[srcindex]]$src,'timing')<-time
 
     # If visible or the value handler has multi args, process and capture output
     if (ev$visible || multi_args) {

--- a/R/eval.r
+++ b/R/eval.r
@@ -28,7 +28,7 @@
 #'   processes the output from the evaluation. The default simply prints the
 #'   visible return values.
 #' @param filename string overrriding the \code{\link[base]{srcfile}} filename.
-#' @param include_tining if \code{TRUE}, evaluate will wrap each input line in
+#' @param include_timing if \code{TRUE}, evaluate will wrap each input line in
 #'   \code{system.time}, which will be accessed by following \code{replay} call
 #'   to produce timing information for each evaluated command. Note, that currently
 #'   this feature will work only if \code{input} is a string.

--- a/R/eval.r
+++ b/R/eval.r
@@ -28,11 +28,15 @@
 #'   processes the output from the evaluation. The default simply prints the
 #'   visible return values.
 #' @param filename string overrriding the \code{\link[base]{srcfile}} filename.
+#' @param include_tining if \code{TRUE}, evaluate will wrap each input line in
+#'   \code{system.time}, which will be accessed by following \code{replay} call
+#'   to produce timing information for each evaluated command. Note, that currently
+#'   this feature will work only if \code{input} is a string.
 #' @import graphics grDevices stringr utils
 evaluate <- function(input, envir = parent.frame(), enclos = NULL, debug = FALSE,
                      stop_on_error = 0L, keep_warning = TRUE, keep_message = TRUE,
                      new_device = TRUE, output_handler = default_output_handler,
-                     filename = NULL) {
+                     filename = NULL, include_timing = FALSE) {
   stop_on_error <- as.integer(stop_on_error)
   stopifnot(length(stop_on_error) == 1)
 
@@ -71,7 +75,8 @@ evaluate <- function(input, envir = parent.frame(), enclos = NULL, debug = FALSE
       envir = envir, enclos = enclos, debug = debug, last = i == length(out),
       use_try = stop_on_error != 2L,
       keep_warning = keep_warning, keep_message = keep_message,
-      output_handler = output_handler)
+      output_handler = output_handler,
+      include_timing = include_timing)
 
     if (stop_on_error > 0L) {
       errs <- vapply(out[[i]], is.error, logical(1))
@@ -88,7 +93,7 @@ evaluate_call <- function(call, src = NULL,
                           envir = parent.frame(), enclos = NULL,
                           debug = FALSE, last = FALSE, use_try = FALSE,
                           keep_warning = TRUE, keep_message = TRUE,
-                          output_handler = new_output_handler()) {
+                          output_handler = new_output_handler(), include_timing = FALSE) {
   if (debug) message(src)
 
   if (is.null(call) && !last) {
@@ -155,13 +160,21 @@ evaluate_call <- function(call, src = NULL,
     handle <- force
   }
   value_handler <- output_handler$value
+  if (include_timing)
+  {
+    timing_fn<-function(x) {system.time(x)[1:3]}
+  } else {
+    timing_fn<-function(x) {x;NULL};
+  }
+
   multi_args <- length(formals(value_handler)) > 1
   for (expr in call) {
-    handle(ev <- withCallingHandlers(
+    time<-timing_fn(handle(ev <- withCallingHandlers(
       withVisible(eval(expr, envir, enclos)),
-      warning = wHandler, error = eHandler, message = mHandler))
+      warning = wHandler, error = eHandler, message = mHandler)))
     handle_output(TRUE)
-
+    if (!is.null(time))
+      attr(output[[length(output)]]$src,'timing')<-time
 
     # If visible or the value handler has multi args, process and capture output
     if (ev$visible || multi_args) {

--- a/R/replay.r
+++ b/R/replay.r
@@ -64,6 +64,42 @@ replay.recordedplot <- function(x) {
   print(x)
 }
 
+render_timing<-function(t)
+{
+  if (max(t)<0.5)
+    return('')
+  return(paste0('[',render_sec(t[[1]]+t[[2]]),',',render_sec(t[[3]]),']'))
+}
+
+render_sec<-function(s)
+{
+  if (s<0.005)
+    return('')
+  if (s<1)
+  {
+    return(paste0(round(s,2),'s'))
+  }
+  if (s<10)
+    return(paste0(round(s,1),'s'))
+  sec<-round(s,0)
+  if (sec<120)
+    return(paste0(sec,'s'))
+  min<-floor(sec/60)
+  sec<-sec - min*60
+  if (min<10)
+    return(paste0(min,'m',formatC(sec, digits = 0, width = 2, format = "f", flag = "0"),'s'))
+  min<-min+round(sec/60,0)
+  if (min<120)
+    return(paste0(min,'m'))
+  h<-floor(min/60)
+  min<-min - h*60
+  if (h<48)
+    return(paste0(h,'h',formatC(min, digits = 0, width = 2, format = "f", flag = "0"),'m'))
+  d<-floor(h/24)
+  h<-h - d*24
+  return(paste0(d,'d',h,'h'))
+}
+
 #' Line prompt.
 #'
 #' Format a single expression as if it had been entered at the command prompt.
@@ -77,7 +113,14 @@ line_prompt <- function(x, prompt = getOption("prompt"), continue = getOption("c
   lines <- strsplit(x, "\n")[[1]]
   n <- length(lines)
 
-  lines[1] <- str_c(prompt, lines[1])
+  if (!is.null(attr(x,'timing')))
+  {
+    s<-attr(x,'timing')
+    s<-render_timing(s)
+    lines[1] <- str_c(s, prompt, lines[1])
+  } else {
+    lines[1] <- str_c(prompt, lines[1])
+  }
   if (n > 1)
     lines[2:n] <- str_c(continue, lines[2:n])
 


### PR DESCRIPTION
It implements my feature request #68 . 

If you have no objections to my implementation, please merge it upstream. That would make my life much easier. 