### PR TITLE
Add encoding option to evaluate and parse_all

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 Version 0.10
 ------------------------------------------------------------------------------
 
+* Added `encoding` option for `parse_all()` and `evaluate`, to specify what
+* encoding the code should be parsed with. (@jimhester, #74)
+
 * Added option for the evaluate function to include timing information of ran
   commands. This information will be subsequently rendered by the replay.
   Example usage:

--- a/R/eval.r
+++ b/R/eval.r
@@ -32,15 +32,16 @@
 #'   expression in \code{system.time()}, which will be accessed by following
 #'   \code{replay()} call to produce timing information for each evaluated
 #'   command.
+#' @inheritParams parse_all
 #' @import graphics grDevices stringr utils
 evaluate <- function(input, envir = parent.frame(), enclos = NULL, debug = FALSE,
                      stop_on_error = 0L, keep_warning = TRUE, keep_message = TRUE,
                      new_device = TRUE, output_handler = default_output_handler,
-                     filename = NULL, include_timing = FALSE) {
+                     filename = NULL, include_timing = FALSE, encoding = "UTF-8") {
   stop_on_error <- as.integer(stop_on_error)
   stopifnot(length(stop_on_error) == 1)
 
-  parsed <- parse_all(input, filename, stop_on_error != 2L)
+  parsed <- parse_all(input, filename, stop_on_error != 2L, encoding = encoding)
   if (inherits(err <- attr(parsed, 'PARSE_ERROR'), 'error')) {
     source <- new_source(parsed$src)
     output_handler$source(source)

--- a/R/parse.r
+++ b/R/parse.r
@@ -6,15 +6,16 @@
 #' @param x object to parse.  Can be a string, a file connection, or a function
 #' @param filename string overriding the file name
 #' @param allow_error whether to allow syntax errors in \code{x}
+#' @param encoding The input encoding assumed when parsing.
 #' @return A data.frame with columns \code{src}, the source code, and
 #'   \code{expr}. If there are syntax errors in \code{x} and \code{allow_error =
 #'   TRUE}, the data frame has an attribute \code{PARSE_ERROR} that stores the
 #'   error object.
 #' @export
-parse_all <- function(x, filename = NULL, allow_error = FALSE) UseMethod("parse_all")
+parse_all <- function(x, filename = NULL, allow_error = FALSE, encoding = "UTF-8") UseMethod("parse_all")
 
 #' @export
-parse_all.character <- function(x, filename = NULL, allow_error = FALSE) {
+parse_all.character <- function(x, filename = NULL, allow_error = FALSE, encoding = "UTF-8") {
 
   # Do not convert strings to factors by default in data.frame()
   op <- options(stringsAsFactors = FALSE)
@@ -28,13 +29,13 @@ parse_all.character <- function(x, filename = NULL, allow_error = FALSE) {
     filename <- "<text>"
   src <- srcfilecopy(filename, x)
   if (allow_error) {
-    exprs <- tryCatch(parse(text = x, srcfile = src), error = identity)
+    exprs <- tryCatch(parse(text = x, srcfile = src, encoding = encoding), error = identity)
     if (inherits(exprs, 'error')) return(structure(
       data.frame(src = paste(x, collapse = '\n'), expr = I(list(expression()))),
       PARSE_ERROR = exprs
     ))
   } else {
-    exprs <- parse(text = x, srcfile = src)
+    exprs <- parse(text = x, srcfile = src, encoding = encoding)
   }
 
   # No code, only comments and/or empty lines

--- a/tests/testthat/test-parse.r
+++ b/tests/testthat/test-parse.r
@@ -31,4 +31,11 @@ if (identical(Sys.getlocale("LC_CTYPE"), "en_US.UTF-8")) {
     expect_identical(parse_all(code)$src, append_break(code))
   })
 
+  test_that("Code is parsed with requested encoding", {
+    cl <- call('Encoding', "寿司")
+
+    expect_identical(Encoding(parse_all(cl, encoding = "UTF-8")$expr[[c(1, 1, 2)]]), "UTF-8")
+    expect_identical(Encoding(parse_all(cl, encoding = "latin1")$expr[[c(1, 1, 2)]]), "latin1")
+    expect_identical(Encoding(parse_all(cl, encoding = "unknown")$expr[[c(1, 1, 2)]]), "unknown")
+  })
 }


### PR DESCRIPTION
This allows one to specify the encoding the code is parsed with, and is
passed to `base::parse()`. Previously the encoding was implicitly
"unknown", so only the code was assumed to be ASCII.

Fixes #74