### PR TITLE
Use original source for evaluating call objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: evaluate
 Type: Package
 Title: Parsing and Evaluation Tools that Provide More Details than the Default
-Version: 0.11
+Version: 0.10.1
 Date: 2017-06-22
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: evaluate
 Type: Package
 Title: Parsing and Evaluation Tools that Provide More Details than the Default
-Version: 0.10
-Date: 2016-10-10
+Version: 0.11
+Date: 2017-06-22
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),
     person("Yihui", "Xie", role = c("cre", "ctb"), email = "xie@yihui.name"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Version 0.11
+------------------------------------------------------------------------------
+
+* Added parse_all.call() method to use the original source for evaluating call
+  objects (because base::deparse() breaks non-ascii source code) (fixes #74)
+
 Version 0.10
 ------------------------------------------------------------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-Version 0.11
+Version 0.11 (unreleased)
 ------------------------------------------------------------------------------
 
 * Added parse_all.call() method to use the original source for evaluating call

--- a/R/parse.r
+++ b/R/parse.r
@@ -177,6 +177,6 @@ parse_all.call <- function(x, filename = NULL, ...) {
   expr <- list(as.expression(x))
   src <- deparse(x)
   out <- data.frame(src = src, stringsAsFactors = FALSE)
-  out$expr = expr
+  out$expr <- expr
   out
 }

--- a/R/parse.r
+++ b/R/parse.r
@@ -170,3 +170,13 @@ parse_all.default <- function(x, filename = NULL, ...) {
     filename <- "<expression>"
   parse_all(deparse(x), filename, ...)
 }
+
+# Calls are already parsed and always length one
+#' @export
+parse_all.call <- function(x, filename = NULL, ...) {
+  expr <- list(as.expression(x))
+  src <- deparse(x)
+  out <- data.frame(src = src, stringsAsFactors = FALSE)
+  out$expr = expr
+  out
+}


### PR DESCRIPTION
Alternate solution to: https://github.com/hadley/evaluate/issues/74

