### PR TITLE
Use default method for parsing calls: fix #77

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: evaluate
 Type: Package
 Title: Parsing and Evaluation Tools that Provide More Details than the Default
-Version: 0.10.1
+Version: 0.10.2
 Date: 2017-06-22
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,9 @@
-Version 0.11 (unreleased)
+Version 0.10.2
+------------------------------------------------------------------------------
+
+* Fix for regression introduced in 0.10.1 in parse_all.call() (fixes #77)
+
+Version 0.10.1
 ------------------------------------------------------------------------------
 
 * Added parse_all.call() method to use the original source for evaluating call

--- a/R/parse.r
+++ b/R/parse.r
@@ -174,9 +174,7 @@ parse_all.default <- function(x, filename = NULL, ...) {
 # Calls are already parsed and always length one
 #' @export
 parse_all.call <- function(x, filename = NULL, ...) {
-  expr <- list(as.expression(x))
-  src <- deparse(x)
-  out <- data.frame(src = src, stringsAsFactors = FALSE)
-  out$expr <- expr
+  out <- parse_all.default(x, filename = filename, ...)
+  out$expr <- list(as.expression(x))
   out
 }


### PR DESCRIPTION
Still need to triple check this but I think this should fix #77. It seems easier too.