### PR TITLE
Do not handle warnings when option(warn) >= 2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ Authors@R: c(
     person("Thomas", "Kluyver", role = "ctb"),
     person("Jeroen", "Ooms", role = "ctb"),
     person("Barret", "Schloerke", role = "ctb"),
-    person("Adam", "Ryczkowski", role = "ctb")
+    person("Adam", "Ryczkowski", role = "ctb"),
+    person("Hiroaki", "Yutani", role = "ctb")
     )
 Description: Parsing and evaluation tools that make it easy to recreate the
     command line behaviour of R.

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@ Version 0.10.2
 ------------------------------------------------------------------------------
 
 * Fix for regression introduced in 0.10.1 in parse_all.call() (fixes #77)
+* evaluate() now respects options(warn >= 2); all warnings are turned into
+  errors (#81)
 
 Version 0.10.1
 ------------------------------------------------------------------------------

--- a/R/eval.r
+++ b/R/eval.r
@@ -141,6 +141,9 @@ evaluate_call <- function(call, src = NULL,
 
   # Handlers for warnings, errors and messages
   wHandler <- if (keep_warning) function(wn) {
+    # do not handle the warning as it will be raised as error after
+    if (getOption("warn") >= 2) return()
+
     if (getOption("warn") >= 0) {
       handle_condition(wn)
       output_handler$warning(wn)

--- a/tests/testthat/test-evaluate.r
+++ b/tests/testthat/test-evaluate.r
@@ -47,7 +47,7 @@ test_that("options(warn = -1) suppresses warnings", {
   expect_that(classes(ev), equals("source"))
 })
 
-test_that("options(warn = 0) and options(warn = 0) produces warnings", {
+test_that("options(warn = 0) and options(warn = 1) produces warnings", {
   ev <- evaluate("op = options(warn = 0); warning('hi'); options(op)")
   expect_equal(classes(ev), c("source", "simpleWarning"))
 

--- a/tests/testthat/test-evaluate.r
+++ b/tests/testthat/test-evaluate.r
@@ -47,6 +47,20 @@ test_that("options(warn = -1) suppresses warnings", {
   expect_that(classes(ev), equals("source"))
 })
 
+test_that("options(warn = 0) and options(warn = 0) produces warnings", {
+  ev <- evaluate("op = options(warn = 0); warning('hi'); options(op)")
+  expect_equal(classes(ev), c("source", "simpleWarning"))
+
+  ev <- evaluate("op = options(warn = 1); warning('hi'); options(op)")
+  expect_equal(classes(ev), c("source", "simpleWarning"))
+})
+
+# errors won't work regularly in test_that()
+ev_warn_2 <- evaluate("op = options(warn = 2); warning('hi'); options(op)")
+test_that("options(warn = 2) produces errors instead of warnings", {
+  expect_equal(classes(ev_warn_2), c("source", "simpleError"))
+})
+
 test_that("output and plots interleaved correctly", {
   ev <- evaluate(file("interleave-1.r"))
   expect_equal(classes(ev),


### PR DESCRIPTION
(This PR fixes https://github.com/yihui/knitr/issues/1425 partly)

According to `?options`:

1. If warn is negative all warnings are ignored.
1. If warn is zero (the default) warnings are stored until the top–level function returns.
1. If warn is one, warnings are printed as they occur.
1. If warn is two or larger all warnings are turned into errors.

But, since [`withCallingHandlers()` doesn't respect `options(warn)`](https://github.com/yihui/knitr/issues/610#issuecomment-25057284), we need some tweaks to emulate the behavior; The default behavior of `evaluate()` is 3, 1. was fixed by yihui's commit (https://github.com/hadley/evaluate/commit/2caeebde0dd56c3d0bd9bf03ced1c66129d6b6b4) long ago, and 2. and 4. are not addressed so far.

This PR fixes 4. If `option(warn)` is 2 or larger, an error will be raised after a warning. The current implementation aborts the process by `invokeRestart("muffleWarning")` after handling the warning. It is better to do nothing when the error follows a warning.